### PR TITLE
Fix race condition in the librtmp install target.

### DIFF
--- a/librtmp/Makefile
+++ b/librtmp/Makefile
@@ -108,13 +108,14 @@ librtmp.pc: librtmp.pc.in Makefile
 install:	install_base $(SO_INST)
 
 install_base:	librtmp.a librtmp.pc
-	-mkdir -p $(INCDIR) $(LIBDIR)/pkgconfig $(MANDIR)/man3 $(SODIR)
+	-mkdir -p $(INCDIR) $(LIBDIR)/pkgconfig $(MANDIR)/man3
 	cp amf.h http.h log.h rtmp.h $(INCDIR)
 	cp librtmp.a $(LIBDIR)
 	cp librtmp.pc $(LIBDIR)/pkgconfig
 	cp librtmp.3 $(MANDIR)/man3
 
 install_so:	librtmp$(SO_EXT)
+	-mkdir -p $(SODIR)
 	cp librtmp$(SO_EXT) $(SODIR)
 	$(INSTALL_IMPLIB)
 	cd $(SODIR); ln -sf librtmp$(SO_EXT) librtmp.$(SOX)


### PR DESCRIPTION
When building rtmpdump sometimes `make install` will fail.

This is because the `install_so` rule depends on the `$(SODIR)` directory, but this directory is created in the `install_base` rule instead. With parallel make the file may be copied before the directory exists which obviously will not work.
```
make[1]: Entering directory '/tmp/SBo/rtmpdump-20151223_fa8646d/librtmp'
mkdir -p /tmp/SBo/package-rtmpdump/usr/include/librtmp /tmp/SBo/package-rtmpdump/usr/lib64/pkgconfig /tmp/SBo/package-rtmpdump/usr/man/man3 /tmp/SBo/package-rtmpdump/usr/lib64
cp librtmp.so.1 /tmp/SBo/package-rtmpdump/usr/lib64
cd /tmp/SBo/package-rtmpdump/usr/lib64; ln -sf librtmp.so.1 librtmp.so
mkdir: cannot create directory '/tmp/SBo/package-rtmpdump/usr/lib64': Not a directory
mkdir: cannot create directory '/tmp/SBo/package-rtmpdump/usr/lib64': File exists
Makefile:111: recipe for target 'install_base' failed
make[1]: [install_base] Error 1 (ignored)
cp amf.h http.h log.h rtmp.h /tmp/SBo/package-rtmpdump/usr/include/librtmp
/bin/sh: line 0: cd: /tmp/SBo/package-rtmpdump/usr/lib64: Not a directory
cp librtmp.a /tmp/SBo/package-rtmpdump/usr/lib64
cp librtmp.pc /tmp/SBo/package-rtmpdump/usr/lib64/pkgconfig
cp: failed to access '/tmp/SBo/package-rtmpdump/usr/lib64/pkgconfig': Not a directory
Makefile:111: recipe for target 'install_base' failed
make[1]: *** [install_base] Error 1
make[1]: Leaving directory '/tmp/SBo/rtmpdump-20151223_fa8646d/librtmp'
Makefile:62: recipe for target 'install' failed
make: *** [install] Error 2
```
This can be easily solved by making sure the `$(SODIR)` directory is created in the `install_so` rule instead.

I also sent this patch to the mailing list and made this PR for visibility.

https://lists.mplayerhq.hu/mailman/listinfo/rtmpdump